### PR TITLE
Avoid using call within forEachChar when its not necessary

### DIFF
--- a/stringview.js
+++ b/stringview.js
@@ -635,7 +635,11 @@ StringView.prototype.forEachChar = function (fCallback, oThat, nChrOffset, nChrL
 
 		for (var nChrCode, nChrIdx = 0; nRawIdx < nRawEnd; nChrIdx++) {
 			nChrCode = fGetInptChrCode(aSource, nRawIdx);
-			fCallback.call(oThat || null, nChrCode, nChrIdx, nRawIdx, aSource);
+			if (!oThat) {
+				fCallback(nChrCode, nChrIdx, nRawIdx, aSource);
+			} else {
+				fCallback.call(oThat, nChrCode, nChrIdx, nRawIdx, aSource);
+			}
 			nRawIdx += fGetInptChrSize(nChrCode);
 		}
 
@@ -645,7 +649,11 @@ StringView.prototype.forEachChar = function (fCallback, oThat, nChrOffset, nChrL
 		nRawEnd = isFinite(nChrLen) ? nChrLen + nRawIdx : aSource.length;
 
 		for (nRawIdx; nRawIdx < nRawEnd; nRawIdx++) {
-			fCallback.call(oThat || null, aSource[nRawIdx], nRawIdx, nRawIdx, aSource);
+			if (!oThat) {
+				fCallback(aSource[nRawIdx], nRawIdx, nRawIdx, aSource);
+			} else {
+				fCallback.call(oThat, aSource[nRawIdx], nRawIdx, nRawIdx, aSource);
+			}
 		}
 
 	}


### PR DESCRIPTION
Using call instead of direct function invocation causes a lot of overhead when working with large ArrayBuffers. https://jsperf.com/function-calls-direct-vs-apply-vs-call-vs-bind/6

By avoiding call within forEachChar when it's not required it runs twice faster. 

